### PR TITLE
[TEST] update to cb3 using `conda smithy update-cb3`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,13 +9,13 @@ environment:
     secure: ipv/06DzgA7pzz2CIAtbPxZSsphDtF+JFyoWRnXkn3O8j7oRe3rzqj3LOoq2DZp4
 
   matrix:
-    - CONFIG: win_python2.7
+    - CONFIG: win_c_compilervs2008python2.7
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
-    - CONFIG: win_python3.5
+    - CONFIG: win_c_compilervs2015python3.5
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
-    - CONFIG: win_python3.6
+    - CONFIG: win_c_compilervs2015python3.6
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 

--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -1,3 +1,5 @@
+c_compiler:
+- toolchain_c
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_python3.5.yaml
+++ b/.ci_support/linux_python3.5.yaml
@@ -1,3 +1,5 @@
+c_compiler:
+- toolchain_c
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -1,3 +1,5 @@
+c_compiler:
+- toolchain_c
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+c_compiler:
+- toolchain_c
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_python3.5.yaml
+++ b/.ci_support/osx_python3.5.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+c_compiler:
+- toolchain_c
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+c_compiler:
+- toolchain_c
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/win_c_compilervs2008python2.7.yaml
+++ b/.ci_support/win_c_compilervs2008python2.7.yaml
@@ -1,6 +1,11 @@
+c_compiler:
+- vs2008
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.5'
+- '2.7'
+zip_keys:
+- - python
+  - c_compiler

--- a/.ci_support/win_c_compilervs2015python3.5.yaml
+++ b/.ci_support/win_c_compilervs2015python3.5.yaml
@@ -1,6 +1,11 @@
+c_compiler:
+- vs2015
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.5'
+zip_keys:
+- - python
+  - c_compiler

--- a/.ci_support/win_c_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015python3.6.yaml
@@ -1,6 +1,11 @@
+c_compiler:
+- vs2015
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - '3.6'
+zip_keys:
+- - python
+  - c_compiler

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,13 +16,11 @@ source:
 
 build:
   number: 0
-  features:
-    - vc9    # [win and py27]
-    - vc10   # [win and py34]
-    - vc14   # [win and py35]
 
 requirements:
   build:
+    - {{ compiler('c') }}
+  host:
     - python
     - pip
     - cffi


### PR DESCRIPTION
Ran `conda smithy update-cb3` that's proposed in PR https://github.com/conda-forge/conda-smithy/pull/781 to update the recipe to cb3. So, are the added C compilers to this recipe needed?

```
$ conda smithy update-cb3
List of changes done to the recipe:
Renamed build with host
Removing vc features
Removing features section as it is empty
Adding C compiler
```

cc @isuruf 
